### PR TITLE
feat: 일정 유형 시스템 (Anchor/Hard/Soft) 구현

### DIFF
--- a/apps/web/app/components/EventModal.tsx
+++ b/apps/web/app/components/EventModal.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import { AddModal } from './AddModal'
-import { toDateString } from '@time-pie/core'
-import type { Event } from '@time-pie/supabase'
+import { toDateString, SCHEDULE_TYPES, getPurposesByType, PREFERRED_WINDOWS, getPurposeInfo } from '@time-pie/core'
+import type { Event, EventType, EventPurpose, PreferredWindow } from '@time-pie/supabase'
 
 interface EventModalProps {
   isOpen: boolean
@@ -13,29 +13,34 @@ interface EventModalProps {
   selectedDate?: Date
 }
 
-const COLORS = [
-  { name: '업무', value: '#4A90D9' },
-  { name: '개인', value: '#2ECC71' },
-  { name: '미팅', value: '#9B59B6' },
-  { name: '운동', value: '#E74C3C' },
-  { name: '수면', value: '#34495E' },
-  { name: '식사', value: '#F39C12' },
-]
-
 export function EventModal({ isOpen, onClose, onSave, initialData, selectedDate }: EventModalProps) {
   const defaultDate = selectedDate || new Date()
   const dateStr = toDateString(defaultDate)
 
   const [title, setTitle] = useState(initialData?.title || '')
   const [description, setDescription] = useState(initialData?.description || '')
+  const [scheduleType, setScheduleType] = useState<EventType>('hard')
+  const [purpose, setPurpose] = useState<EventPurpose | null>(initialData?.purpose || null)
+
+  // Hard type fields
   const [startDate, setStartDate] = useState(dateStr)
-  const [startTime, setStartTime] = useState(initialData?.start_at?.split('T')[1]?.slice(0, 5) || '09:00')
-  const [endTime, setEndTime] = useState(initialData?.end_at?.split('T')[1]?.slice(0, 5) || '10:00')
-  const [color, setColor] = useState(initialData?.color || COLORS[0].value)
-  const [isAllDay, setIsAllDay] = useState(initialData?.is_all_day || false)
-  const [eventType, setEventType] = useState<'fixed' | 'flexible' | 'recurring'>(
-    initialData?.event_type || 'fixed'
-  )
+  const [startTime, setStartTime] = useState('09:00')
+  const [endTime, setEndTime] = useState('10:00')
+  const [isAllDay, setIsAllDay] = useState(false)
+  const [repeatDays, setRepeatDays] = useState<number[]>([])
+  const [isLocked, setIsLocked] = useState(false)
+  const [location, setLocation] = useState('')
+
+  // Anchor type fields
+  const [baseTime, setBaseTime] = useState('07:00')
+  const [targetDurationMin, setTargetDurationMin] = useState(60)
+  const [bufferMin, setBufferMin] = useState(15)
+
+  // Soft type fields
+  const [weeklyGoal, setWeeklyGoal] = useState(3)
+  const [preferredWindow, setPreferredWindow] = useState<PreferredWindow>('evening')
+  const [priority, setPriority] = useState(3)
+
   const [isSaving, setIsSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
 
@@ -46,41 +51,139 @@ export function EventModal({ isOpen, onClose, onSave, initialData, selectedDate 
 
       setTitle(initialData?.title || '')
       setDescription(initialData?.description || '')
+      setScheduleType(initialData?.event_type || 'hard')
+      setPurpose(initialData?.purpose || null)
+
+      // Hard type fields
       setStartDate(initialData?.start_at?.split('T')[0] || dateStr)
       setStartTime(initialData?.start_at?.split('T')[1]?.slice(0, 5) || '09:00')
       setEndTime(initialData?.end_at?.split('T')[1]?.slice(0, 5) || '10:00')
-      setColor(initialData?.color || COLORS[0].value)
       setIsAllDay(initialData?.is_all_day || false)
-      setEventType(initialData?.event_type || 'fixed')
+      setRepeatDays(initialData?.repeat_days || [])
+      setIsLocked(initialData?.is_locked || false)
+      setLocation(initialData?.location || '')
+
+      // Anchor type fields
+      setBaseTime(initialData?.base_time || '07:00')
+      setTargetDurationMin(initialData?.target_duration_min || 60)
+      setBufferMin(initialData?.buffer_min || 15)
+
+      // Soft type fields
+      setWeeklyGoal(initialData?.weekly_goal || 3)
+      setPreferredWindow(initialData?.preferred_window || 'evening')
+      setPriority(initialData?.priority || 3)
+
+      setIsSaving(false)
+      setSaveError(null)
     }
   }, [isOpen, initialData, selectedDate])
+
+  const toggleRepeatDay = (dayIndex: number) => {
+    setRepeatDays(prev =>
+      prev.includes(dayIndex)
+        ? prev.filter(d => d !== dayIndex)
+        : [...prev, dayIndex].sort()
+    )
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!title.trim() || isSaving) return
 
-    const startAt = isAllDay
-      ? `${startDate}T00:00:00`
-      : `${startDate}T${startTime}:00`
-    const endAt = isAllDay
-      ? `${startDate}T23:59:59`
-      : `${startDate}T${endTime}:00`
-
     setIsSaving(true)
     setSaveError(null)
 
     try {
-      await onSave({
-        title: title.trim(),
-        description: description.trim() || null,
-        start_at: startAt,
-        end_at: endAt,
-        is_all_day: isAllDay,
-        event_type: eventType,
-        color,
-        category_id: null,
-        reminder_min: 15,
-      })
+      const purposeInfo = getPurposeInfo(purpose)
+      let eventData: Omit<Event, 'id' | 'user_id' | 'created_at' | 'updated_at'>
+
+      if (scheduleType === 'anchor') {
+        // Anchor: start_at = date + base_time, end_at = start_at + target_duration_min
+        const startAt = `${startDate}T${baseTime}:00`
+        const startDateTime = new Date(startAt)
+        const endDateTime = new Date(startDateTime.getTime() + targetDurationMin * 60 * 1000)
+        const endAt = endDateTime.toISOString().slice(0, 19)
+
+        eventData = {
+          title: title.trim(),
+          description: description.trim() || null,
+          start_at: startAt,
+          end_at: endAt,
+          is_all_day: false,
+          event_type: 'anchor',
+          color: purposeInfo?.color ?? '#4A90D9',
+          purpose,
+          category_id: null,
+          reminder_min: null,
+          base_time: baseTime,
+          target_duration_min: targetDurationMin,
+          buffer_min: bufferMin,
+          repeat_days: null,
+          is_locked: false,
+          location: null,
+          weekly_goal: null,
+          preferred_window: null,
+          priority: null,
+        }
+      } else if (scheduleType === 'hard') {
+        // Hard: use existing startTime/endTime logic
+        const startAt = isAllDay
+          ? `${startDate}T00:00:00`
+          : `${startDate}T${startTime}:00`
+        const endAt = isAllDay
+          ? `${startDate}T23:59:59`
+          : `${startDate}T${endTime}:00`
+
+        eventData = {
+          title: title.trim(),
+          description: description.trim() || null,
+          start_at: startAt,
+          end_at: endAt,
+          is_all_day: isAllDay,
+          event_type: 'hard',
+          color: purposeInfo?.color ?? '#4A90D9',
+          purpose,
+          category_id: null,
+          reminder_min: null,
+          repeat_days: repeatDays.length > 0 ? repeatDays : null,
+          is_locked: isLocked,
+          location: location.trim() || null,
+          base_time: null,
+          target_duration_min: null,
+          buffer_min: null,
+          weekly_goal: null,
+          preferred_window: null,
+          priority: null,
+        }
+      } else {
+        // Soft: placeholder times, goal-based
+        const startAt = `${startDate}T12:00:00`
+        const endAt = `${startDate}T13:00:00`
+
+        eventData = {
+          title: title.trim(),
+          description: description.trim() || null,
+          start_at: startAt,
+          end_at: endAt,
+          is_all_day: false,
+          event_type: 'soft',
+          color: purposeInfo?.color ?? '#4A90D9',
+          purpose,
+          category_id: null,
+          reminder_min: null,
+          weekly_goal: weeklyGoal,
+          preferred_window: preferredWindow,
+          priority,
+          base_time: null,
+          target_duration_min: null,
+          buffer_min: null,
+          repeat_days: null,
+          is_locked: false,
+          location: null,
+        }
+      }
+
+      await onSave(eventData)
 
       // Reset form only on success
       setTitle('')
@@ -88,7 +191,10 @@ export function EventModal({ isOpen, onClose, onSave, initialData, selectedDate 
       onClose()
     } catch (error) {
       console.error('Event save failed:', error)
-      setSaveError(error instanceof Error ? error.message : '저장에 실패했습니다')
+      const msg = error instanceof Error ? error.message
+        : typeof error === 'object' && error !== null && 'message' in error ? String((error as { message: unknown }).message)
+        : '저장에 실패했습니다'
+      setSaveError(msg)
     } finally {
       setIsSaving(false)
     }
@@ -97,6 +203,25 @@ export function EventModal({ isOpen, onClose, onSave, initialData, selectedDate 
   return (
     <AddModal isOpen={isOpen} onClose={onClose} title="일정 추가">
       <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Schedule Type Tabs */}
+        <div className="flex gap-1 p-1 bg-gray-100 dark:bg-gray-800 rounded-xl mb-4">
+          {SCHEDULE_TYPES.map((type) => (
+            <button
+              key={type.key}
+              type="button"
+              onClick={() => setScheduleType(type.key)}
+              className={`flex-1 py-2.5 px-3 rounded-lg text-sm font-medium transition-all ${
+                scheduleType === type.key
+                  ? 'bg-white dark:bg-gray-700 text-primary shadow-sm'
+                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              <div className="text-base mb-0.5">{type.emoji}</div>
+              <div>{type.label}</div>
+            </button>
+          ))}
+        </div>
+
         {/* Title */}
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">제목</label>
@@ -110,101 +235,246 @@ export function EventModal({ isOpen, onClose, onSave, initialData, selectedDate 
           />
         </div>
 
-        {/* Event Type */}
+        {/* Purpose selector - filtered by type */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">일정 유형</label>
-          <div className="flex gap-2">
-            {([
-              { value: 'fixed', label: '고정', desc: '출근, 수업' },
-              { value: 'flexible', label: '유동', desc: '공부, 독서' },
-              { value: 'recurring', label: '반복', desc: '루틴' },
-            ] as const).map((type) => (
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">약속 유형</label>
+          <div className="grid grid-cols-3 gap-2">
+            {getPurposesByType(scheduleType).map((p) => (
               <button
-                key={type.value}
+                key={p.key}
                 type="button"
-                onClick={() => setEventType(type.value)}
-                className={`flex-1 py-2 px-3 rounded-xl text-sm font-medium transition-all border-2 ${
-                  eventType === type.value
+                onClick={() => setPurpose(p.key)}
+                className={`flex flex-col items-center py-2.5 px-1 rounded-xl text-xs font-medium transition-all border-2 ${
+                  purpose === p.key
                     ? 'border-primary bg-primary/10 text-primary dark:text-primary'
                     : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-gray-300'
                 }`}
               >
-                <div>{type.label}</div>
-                <div className="text-xs opacity-60 mt-0.5">{type.desc}</div>
+                <span className="text-lg mb-0.5">{p.emoji}</span>
+                <span>{p.label}</span>
               </button>
             ))}
           </div>
         </div>
 
-        {/* Date */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">날짜</label>
-          <input
-            type="date"
-            value={startDate}
-            onChange={(e) => setStartDate(e.target.value)}
-            className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
-          />
-        </div>
-
-        {/* All Day Toggle */}
-        <div className="flex items-center gap-3">
-          <input
-            type="checkbox"
-            id="allDay"
-            checked={isAllDay}
-            onChange={(e) => setIsAllDay(e.target.checked)}
-            className="w-5 h-5 rounded border-gray-300 text-primary focus:ring-primary"
-          />
-          <label htmlFor="allDay" className="text-sm font-medium text-gray-700 dark:text-gray-300">
-            하루 종일
-          </label>
-        </div>
-
-        {/* Time */}
-        {!isAllDay && (
-          <div className="grid grid-cols-2 gap-3">
+        {/* === Anchor Form === */}
+        {scheduleType === 'anchor' && (
+          <>
+            {/* Base Time */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">시작</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">기준 시간</label>
               <input
                 type="time"
-                value={startTime}
-                onChange={(e) => setStartTime(e.target.value)}
+                value={baseTime}
+                onChange={(e) => setBaseTime(e.target.value)}
                 className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
               />
             </div>
+
+            {/* Target Duration */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">종료</label>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">목표 시간 (분)</label>
               <input
-                type="time"
-                value={endTime}
-                onChange={(e) => setEndTime(e.target.value)}
+                type="number"
+                value={targetDurationMin}
+                onChange={(e) => setTargetDurationMin(Number(e.target.value))}
+                min={15}
+                max={720}
+                step={15}
                 className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
               />
             </div>
-          </div>
+
+            {/* Buffer */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">유동 허용 (분)</label>
+              <input
+                type="number"
+                value={bufferMin}
+                onChange={(e) => setBufferMin(Number(e.target.value))}
+                min={0}
+                max={120}
+                step={5}
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+              />
+            </div>
+
+            {/* Daily badge */}
+            <div className="text-sm text-gray-500 bg-gray-50 dark:bg-gray-800 rounded-xl p-3 text-center">
+              ⚓ 매일 자동 반복됩니다
+            </div>
+          </>
         )}
 
-        {/* Color */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">카테고리</label>
-          <div className="flex flex-wrap gap-2">
-            {COLORS.map((c) => (
-              <button
-                key={c.value}
-                type="button"
-                onClick={() => setColor(c.value)}
-                className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${color === c.value
-                  ? 'ring-2 ring-offset-2 ring-gray-400'
-                  : 'hover:opacity-80'
-                  }`}
-                style={{ backgroundColor: c.value, color: 'white' }}
-              >
-                {c.name}
-              </button>
-            ))}
-          </div>
-        </div>
+        {/* === Hard Form === */}
+        {scheduleType === 'hard' && (
+          <>
+            {/* Date */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">날짜</label>
+              <input
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+              />
+            </div>
+
+            {/* All Day Toggle */}
+            <div className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                id="allDay"
+                checked={isAllDay}
+                onChange={(e) => setIsAllDay(e.target.checked)}
+                className="w-5 h-5 rounded border-gray-300 text-primary focus:ring-primary"
+              />
+              <label htmlFor="allDay" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                하루 종일
+              </label>
+            </div>
+
+            {/* Start/End Time */}
+            {!isAllDay && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">시작</label>
+                  <input
+                    type="time"
+                    value={startTime}
+                    onChange={(e) => setStartTime(e.target.value)}
+                    className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">종료</label>
+                  <input
+                    type="time"
+                    value={endTime}
+                    onChange={(e) => setEndTime(e.target.value)}
+                    className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Repeat Days */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">반복 요일</label>
+              <div className="flex gap-1">
+                {['일', '월', '화', '수', '목', '금', '토'].map((day, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => toggleRepeatDay(i)}
+                    className={`w-9 h-9 rounded-full text-sm font-medium transition-all ${
+                      repeatDays.includes(i)
+                        ? 'bg-primary text-white'
+                        : 'border-2 border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-gray-300'
+                    }`}
+                  >
+                    {day}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Lock toggle */}
+            <div className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                id="isLocked"
+                checked={isLocked}
+                onChange={(e) => setIsLocked(e.target.checked)}
+                className="w-5 h-5 rounded border-gray-300 text-primary focus:ring-primary"
+              />
+              <label htmlFor="isLocked" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                다른 일정 잠금
+              </label>
+            </div>
+
+            {/* Location */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">장소/링크 (선택)</label>
+              <input
+                type="text"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                placeholder="오프라인 장소 또는 URL"
+                className="w-full px-4 py-3 border border-gray-200 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-xl focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+              />
+            </div>
+          </>
+        )}
+
+        {/* === Soft Form === */}
+        {scheduleType === 'soft' && (
+          <>
+            {/* Weekly Goal */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">주간 목표 (회)</label>
+              <div className="flex gap-2">
+                {[1, 2, 3, 4, 5, 6, 7].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setWeeklyGoal(n)}
+                    className={`flex-1 h-10 rounded-full text-sm font-medium transition-all ${
+                      n === weeklyGoal
+                        ? 'bg-primary text-white'
+                        : 'border-2 border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-gray-300'
+                    }`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Preferred Window */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">선호 시간대</label>
+              <div className="grid grid-cols-4 gap-2">
+                {PREFERRED_WINDOWS.map((w) => (
+                  <button
+                    key={w.key}
+                    type="button"
+                    onClick={() => setPreferredWindow(w.key as PreferredWindow)}
+                    className={`py-2 px-2 rounded-xl text-xs font-medium transition-all border-2 ${
+                      w.key === preferredWindow
+                        ? 'border-primary bg-primary/10 text-primary dark:text-primary'
+                        : 'border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-gray-300'
+                    }`}
+                  >
+                    <div className="font-semibold">{w.label}</div>
+                    <div className="text-[10px] opacity-60 mt-0.5">{w.range}</div>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Priority */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">우선순위</label>
+              <div className="flex gap-2">
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setPriority(n)}
+                    className={`flex-1 h-10 rounded-full text-sm font-medium transition-all ${
+                      n === priority
+                        ? 'bg-primary text-white'
+                        : 'border-2 border-gray-200 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:border-gray-300'
+                    }`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
 
         {/* Description */}
         <div>

--- a/docs/PLAN-event-purpose.md
+++ b/docs/PLAN-event-purpose.md
@@ -1,0 +1,90 @@
+# 약속 유형 (Event Purpose) 추가 계획
+
+## Context
+
+현재 EventModal에서 "카테고리"라는 이름으로 색상만 선택하는 UI가 있음 (업무, 개인, 미팅, 운동, 수면, 식사). 하지만 이 선택이 DB에 의미 있게 저장되지 않고 `color` 값만 반영됨. `category_id`는 항상 `null`.
+
+사용자가 원하는 것: 일정 추가 시 목적별 분류(약속 유형)를 이모지+라벨로 선택하고, 해당 정보가 DB에 저장되어 이벤트 표시 시에도 보이도록 하는 것.
+
+## 접근 방식
+
+`events` 테이블에 `purpose TEXT` 컬럼을 추가하고, 기존 색상 피커를 이모지가 포함된 약속 유형 선택기로 교체.
+
+- `event_type` (고정/유동/반복) = 일정의 **스케줄 방식**
+- `purpose` (업무/미팅/약속/운동 등) = 일정의 **목적** (새로 추가)
+
+## 변경 파일 및 상세
+
+### 1. DB 스키마: `packages/supabase/schema.sql`
+
+events 테이블에 `purpose` 컬럼 추가 (line 28 뒤):
+```sql
+purpose TEXT CHECK (purpose IN ('work','meeting','appointment','personal','exercise','study','meal','sleep','commute','hobby','other')),
+```
+- nullable (기존 이벤트 호환)
+- CHECK constraint로 유효값 제한
+
+### 2. 타입: `packages/supabase/src/types.ts`
+
+- `EventPurpose` 타입 추가: `'work' | 'meeting' | ... | 'other'`
+- `Event` 인터페이스에 `purpose: EventPurpose | null` 필드 추가 (line 35 뒤)
+- `EventInsert`, `EventUpdate`는 Omit/Partial 기반이라 자동 반영
+
+### 3. 상수 정의: `packages/core/src/constants/purposes.ts` (새 파일)
+
+```typescript
+export const EVENT_PURPOSES = [
+  { key: 'work',        label: '업무', emoji: '💼', color: '#4A90D9' },
+  { key: 'meeting',     label: '미팅', emoji: '🤝', color: '#9B59B6' },
+  { key: 'appointment', label: '약속', emoji: '📅', color: '#E67E22' },
+  { key: 'personal',    label: '개인', emoji: '🏠', color: '#2ECC71' },
+  { key: 'exercise',    label: '운동', emoji: '🏃', color: '#E74C3C' },
+  { key: 'study',       label: '공부', emoji: '📚', color: '#3498DB' },
+  { key: 'meal',        label: '식사', emoji: '🍽️', color: '#F39C12' },
+  { key: 'sleep',       label: '수면', emoji: '🌙', color: '#34495E' },
+  { key: 'commute',     label: '이동', emoji: '🚗', color: '#95A5A6' },
+  { key: 'hobby',       label: '취미', emoji: '🎨', color: '#1ABC9C' },
+  { key: 'other',       label: '기타', emoji: '📌', color: '#7F8C8D' },
+]
+```
+- `getPurposeInfo(key)` 헬퍼 함수 포함
+- `packages/core/src/index.ts`에서 export 추가
+
+### 4. EventModal UI: `apps/web/app/components/EventModal.tsx`
+
+- `COLORS` 배열 제거 (line 16-23)
+- `purpose` 상태 추가, `color`는 purpose 선택 시 자동 설정
+- 기존 "카테고리" 색상 피커 (line 188-207) → "약속 유형" 이모지 그리드로 교체
+  - `grid grid-cols-4 gap-2` 레이아웃
+  - 각 버튼: 이모지 + 한글 라벨
+  - 활성 상태: `border-primary bg-primary/10` (기존 event_type 패턴과 동일)
+- `handleSubmit`에 `purpose` 포함 (line 73-83)
+- `useEffect` 리셋에 `purpose` 포함 (line 42-56)
+
+### 5. 이벤트 표시: `apps/web/app/page.tsx`
+
+- 파이차트 Legend (line 206-225): 이벤트 제목 앞에 purpose 이모지 표시
+- 리스트 뷰 (line 236-276): 이벤트 제목 앞에 purpose 이모지 표시
+- `getPurposeInfo` import 추가
+
+### 변경 불필요 파일
+
+- `packages/supabase/src/queries/events.ts`: `select('*')` 사용 → purpose 자동 포함
+- `packages/core/src/stores/eventStore.ts`: Event 타입 자동 반영
+- `packages/core/src/hooks/useUserData.ts`: EventInsert 전달만 함
+- `apps/mobile/`: WebView 래퍼 → 웹 변경사항 자동 반영
+
+## 구현 순서
+
+1. `schema.sql` - purpose 컬럼 추가
+2. `types.ts` - EventPurpose 타입 + Event에 purpose 필드
+3. `purposes.ts` 새 파일 + core index export
+4. `EventModal.tsx` - 색상 피커 → 약속 유형 선택기
+5. `page.tsx` - 이벤트 표시에 이모지 추가
+
+## 검증 방법
+
+1. `pnpm build` (apps/web) - 타입 에러 없는지 확인
+2. EventModal에서 약속 유형 선택 후 저장 → DB에 purpose 값 저장 확인
+3. 홈 파이차트/리스트에서 이모지 표시 확인
+4. purpose 미선택 시 null로 저장되어 기존 이벤트와 호환 확인

--- a/packages/core/src/constants/purposes.ts
+++ b/packages/core/src/constants/purposes.ts
@@ -1,0 +1,76 @@
+import type { EventPurpose, EventType } from '@time-pie/supabase'
+
+export interface PurposeInfo {
+  key: EventPurpose
+  label: string
+  emoji: string
+  color: string
+}
+
+export interface ScheduleTypeInfo {
+  key: EventType
+  label: string
+  emoji: string
+  description: string
+}
+
+// Schedule type definitions
+export const SCHEDULE_TYPES: ScheduleTypeInfo[] = [
+  { key: 'anchor', label: '앵커', emoji: '⚓', description: '매일 반복되는 필수 일정' },
+  { key: 'hard',   label: '하드 블록', emoji: '🔒', description: '고정된 시간의 약속' },
+  { key: 'soft',   label: '소프트 루틴', emoji: '☁️', description: '유연한 자기관리 시간' },
+]
+
+const SCHEDULE_TYPE_MAP = new Map(SCHEDULE_TYPES.map(t => [t.key, t]))
+
+export function getScheduleTypeInfo(key: EventType): ScheduleTypeInfo | undefined {
+  return SCHEDULE_TYPE_MAP.get(key)
+}
+
+// All purposes (kept flat for DB CHECK constraint compatibility)
+export const EVENT_PURPOSES: PurposeInfo[] = [
+  { key: 'sleep',       label: '수면', emoji: '🌙', color: '#34495E' },
+  { key: 'meal',        label: '식사', emoji: '🍽️', color: '#F39C12' },
+  { key: 'personal',    label: '개인', emoji: '🏠', color: '#2ECC71' },
+  { key: 'work',        label: '업무', emoji: '💼', color: '#4A90D9' },
+  { key: 'meeting',     label: '미팅', emoji: '🤝', color: '#9B59B6' },
+  { key: 'appointment', label: '약속', emoji: '📅', color: '#E67E22' },
+  { key: 'commute',     label: '이동', emoji: '🚗', color: '#95A5A6' },
+  { key: 'exercise',    label: '운동', emoji: '🏃', color: '#E74C3C' },
+  { key: 'study',       label: '공부', emoji: '📚', color: '#3498DB' },
+  { key: 'hobby',       label: '취미', emoji: '🎨', color: '#1ABC9C' },
+  { key: 'other',       label: '기타', emoji: '📌', color: '#7F8C8D' },
+]
+
+// Purpose grouped by schedule type
+export const PURPOSES_BY_TYPE: Record<EventType, EventPurpose[]> = {
+  anchor: ['sleep', 'meal', 'personal'],
+  hard:   ['work', 'meeting', 'appointment', 'commute'],
+  soft:   ['exercise', 'study', 'hobby', 'other'],
+}
+
+export function getPurposesByType(type: EventType): PurposeInfo[] {
+  const keys = PURPOSES_BY_TYPE[type]
+  return EVENT_PURPOSES.filter(p => keys.includes(p.key))
+}
+
+const PURPOSE_MAP = new Map(EVENT_PURPOSES.map(p => [p.key, p]))
+
+export function getPurposeInfo(key: EventPurpose | null | undefined): PurposeInfo | undefined {
+  if (!key) return undefined
+  return PURPOSE_MAP.get(key)
+}
+
+// Preferred time windows for soft routines
+export interface PreferredWindowInfo {
+  key: string
+  label: string
+  range: string
+}
+
+export const PREFERRED_WINDOWS: PreferredWindowInfo[] = [
+  { key: 'morning',   label: '오전',  range: '06:00~12:00' },
+  { key: 'afternoon', label: '오후',  range: '12:00~18:00' },
+  { key: 'evening',   label: '저녁',  range: '18:00~22:00' },
+  { key: 'night',     label: '밤',    range: '22:00~06:00' },
+]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './stores'
 export * from './hooks'
 export * from './utils'
+export * from './constants/purposes'

--- a/packages/core/src/utils/analysis.ts
+++ b/packages/core/src/utils/analysis.ts
@@ -47,7 +47,7 @@ export function detectUnrealisticPlans(
 ): UnrealisticPlanWarning[] {
   const warnings: UnrealisticPlanWarning[] = []
 
-  const flexibleEvents = events.filter((e) => e.event_type === 'flexible')
+  const flexibleEvents = events.filter((e) => e.event_type === 'soft')
 
   for (const event of flexibleEvents) {
     const eventExecs = executions.filter((e) => e.event_id === event.id)
@@ -81,7 +81,7 @@ export function suggestTimeAdjustments(
 ): TimeAdjustmentSuggestion[] {
   const suggestions: TimeAdjustmentSuggestion[] = []
 
-  const flexibleEvents = events.filter((e) => e.event_type === 'flexible')
+  const flexibleEvents = events.filter((e) => e.event_type === 'soft')
 
   for (const event of flexibleEvents) {
     const completedExecs = executions.filter(

--- a/packages/supabase/schema.sql
+++ b/packages/supabase/schema.sql
@@ -20,10 +20,23 @@ CREATE TABLE IF NOT EXISTS events (
   start_at TIMESTAMPTZ NOT NULL,
   end_at TIMESTAMPTZ NOT NULL,
   is_all_day BOOLEAN NOT NULL DEFAULT false,
-  event_type TEXT NOT NULL DEFAULT 'fixed' CHECK (event_type IN ('fixed', 'flexible', 'recurring')),
+  event_type TEXT NOT NULL DEFAULT 'hard' CHECK (event_type IN ('anchor', 'hard', 'soft')),
   color TEXT NOT NULL DEFAULT '#4A90D9',
+  purpose TEXT CHECK (purpose IN ('work', 'meeting', 'appointment', 'personal', 'exercise', 'study', 'meal', 'sleep', 'commute', 'hobby', 'other')),
   category_id UUID REFERENCES categories(id) ON DELETE SET NULL,
   reminder_min INTEGER,
+  -- Anchor-specific
+  base_time TIME,
+  target_duration_min INTEGER,
+  buffer_min INTEGER DEFAULT 0,
+  -- Hard-specific
+  repeat_days INTEGER[],
+  is_locked BOOLEAN NOT NULL DEFAULT false,
+  location TEXT,
+  -- Soft-specific
+  weekly_goal INTEGER,
+  preferred_window TEXT CHECK (preferred_window IN ('morning', 'afternoon', 'evening', 'night')),
+  priority INTEGER DEFAULT 3,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -1,6 +1,8 @@
 // 수동 타입 정의 (Supabase 연결 후 자동 생성으로 대체 가능)
 
-export type EventType = 'fixed' | 'flexible' | 'recurring'
+export type EventType = 'anchor' | 'hard' | 'soft'
+export type EventPurpose = 'work' | 'meeting' | 'appointment' | 'personal' | 'exercise' | 'study' | 'meal' | 'sleep' | 'commute' | 'hobby' | 'other'
+export type PreferredWindow = 'morning' | 'afternoon' | 'evening' | 'night'
 export type ExecutionStatus = 'planned' | 'in_progress' | 'completed' | 'skipped' | 'partial'
 export type SuggestionType = 'time_adjustment' | 'unrealistic_warning' | 'pattern_insight'
 
@@ -32,8 +34,21 @@ export interface Event {
   is_all_day: boolean
   event_type: EventType
   color: string
+  purpose: EventPurpose | null
   category_id: string | null
   reminder_min: number | null
+  // Anchor-specific
+  base_time: string | null
+  target_duration_min: number | null
+  buffer_min: number | null
+  // Hard-specific
+  repeat_days: number[] | null
+  is_locked: boolean
+  location: string | null
+  // Soft-specific
+  weekly_goal: number | null
+  preferred_window: PreferredWindow | null
+  priority: number | null
   created_at: string
   updated_at: string
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,5 +22,8 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "typescript": "^5.9.0"
+  },
+  "dependencies": {
+    "framer-motion": "^12.34.0"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,7 @@
 // Components
 export * from './pie-chart'
+export * from './spinner'
 
 // Types
 export type { PieChartProps, TimeSlice } from './pie-chart/types'
+export type { SpinnerProps } from './spinner'

--- a/packages/ui/src/pie-chart/PieChart.tsx
+++ b/packages/ui/src/pie-chart/PieChart.tsx
@@ -12,10 +12,6 @@ import {
 
 const HOUR_LABELS = [0, 3, 6, 9, 12, 15, 18, 21]
 
-function colorToId(color: string): string {
-  return color.replace('#', '').replace(/[^a-zA-Z0-9]/g, '')
-}
-
 export function PieChart({
   events,
   currentTime = new Date(),
@@ -39,17 +35,6 @@ export function PieChart({
     [currentTime]
   )
 
-  // Collect unique colors for pattern generation
-  const patternColors = useMemo(() => {
-    const flexible = new Set<string>()
-    const recurring = new Set<string>()
-    for (const slice of slices) {
-      if (slice.eventType === 'flexible') flexible.add(slice.color)
-      if (slice.eventType === 'recurring') recurring.add(slice.color)
-    }
-    return { flexible: Array.from(flexible), recurring: Array.from(recurring) }
-  }, [slices])
-
   const handleSliceClick = (slice: (typeof slices)[0], hour: number) => {
     if (slice.event && onEventClick) {
       onEventClick(slice.event)
@@ -68,44 +53,6 @@ export function PieChart({
         height={size + 50}
         viewBox={`-25 -25 ${size + 50} ${size + 50}`}
       >
-        {/* SVG Pattern Definitions */}
-        <defs>
-          {/* Hatch patterns for flexible events */}
-          {patternColors.flexible.map((color) => (
-            <pattern
-              key={`hatch-${color}`}
-              id={`hatch-${colorToId(color)}`}
-              patternUnits="userSpaceOnUse"
-              width="8"
-              height="8"
-              patternTransform="rotate(45)"
-            >
-              <line
-                x1="0" y1="0" x2="0" y2="8"
-                stroke="white"
-                strokeWidth="2.5"
-                strokeOpacity="0.4"
-              />
-            </pattern>
-          ))}
-          {/* Dot patterns for recurring events */}
-          {patternColors.recurring.map((color) => (
-            <pattern
-              key={`dots-${color}`}
-              id={`dots-${colorToId(color)}`}
-              patternUnits="userSpaceOnUse"
-              width="10"
-              height="10"
-            >
-              <circle
-                cx="5" cy="5" r="1.8"
-                fill="white"
-                fillOpacity="0.45"
-              />
-            </pattern>
-          ))}
-        </defs>
-
         {/* 파이 조각들 */}
         {slices.map((slice, index) => {
           const path = describeArc(
@@ -117,39 +64,30 @@ export function PieChart({
           )
           const midAngle = (slice.startAngle + slice.endAngle) / 2
           const hour = Math.floor((midAngle / 360) * 24)
-          const colorId = colorToId(slice.color)
+
+          // Determine style based on event type
+          const isAnchor = slice.eventType === 'anchor'
+          const isHard = slice.eventType === 'hard'
+          const isSoft = slice.eventType === 'soft'
 
           return (
             <g key={index} onClick={() => handleSliceClick(slice, hour)}>
-              {/* Base color fill */}
               <path
                 d={path}
                 fill={slice.color}
-                stroke="white"
-                strokeWidth={2}
+                stroke={slice.isEmpty ? 'white' : isSoft ? slice.color : 'white'}
+                strokeWidth={slice.isEmpty ? 2 : isHard ? 3 : isSoft ? 2 : 1}
+                strokeDasharray={isSoft && !slice.isEmpty ? '6 3' : undefined}
                 className={`transition-opacity ${
                   slice.isEmpty
                     ? 'opacity-30 hover:opacity-50'
-                    : 'opacity-90 hover:opacity-100 cursor-pointer'
+                    : isAnchor
+                      ? 'opacity-60 hover:opacity-75 cursor-pointer'
+                      : isSoft
+                        ? 'opacity-40 hover:opacity-60 cursor-pointer'
+                        : 'opacity-100 hover:opacity-90 cursor-pointer'
                 }`}
               />
-              {/* Pattern overlay for flexible/recurring */}
-              {slice.eventType === 'flexible' && !slice.isEmpty && (
-                <path
-                  d={path}
-                  fill={`url(#hatch-${colorId})`}
-                  stroke="none"
-                  className="pointer-events-none"
-                />
-              )}
-              {slice.eventType === 'recurring' && !slice.isEmpty && (
-                <path
-                  d={path}
-                  fill={`url(#dots-${colorId})`}
-                  stroke="none"
-                  className="pointer-events-none"
-                />
-              )}
             </g>
           )
         })}

--- a/packages/ui/src/pie-chart/types.ts
+++ b/packages/ui/src/pie-chart/types.ts
@@ -5,7 +5,7 @@ export interface Event {
   end_at: string
   color: string
   category?: string
-  event_type?: 'fixed' | 'flexible' | 'recurring'
+  event_type?: 'anchor' | 'hard' | 'soft'
 }
 
 export interface TimeSlice {
@@ -14,7 +14,7 @@ export interface TimeSlice {
   event?: Event
   color: string
   isEmpty: boolean
-  eventType?: 'fixed' | 'flexible' | 'recurring'
+  eventType?: 'anchor' | 'hard' | 'soft'
 }
 
 export interface PieChartProps {

--- a/packages/ui/src/spinner/Spinner.tsx
+++ b/packages/ui/src/spinner/Spinner.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export interface SpinnerProps {
+  size?: 'sm' | 'md' | 'lg'
+  label?: string
+  fullScreen?: boolean
+}
+
+const sizeMap = {
+  sm: 20,
+  md: 32,
+  lg: 48,
+}
+
+const borderMap = {
+  sm: 2,
+  md: 3,
+  lg: 4,
+}
+
+export function Spinner({ size = 'md', label, fullScreen = false }: SpinnerProps) {
+  const px = sizeMap[size]
+  const border = borderMap[size]
+
+  const spinner = (
+    <div className="flex flex-col items-center gap-2">
+      <motion.div
+        style={{
+          width: px,
+          height: px,
+          border: `${border}px solid rgba(156, 163, 175, 0.3)`,
+          borderTop: `${border}px solid #FF6B35`,
+          borderRadius: '50%',
+        }}
+        animate={{ rotate: 360 }}
+        transition={{
+          duration: 0.8,
+          repeat: Infinity,
+          ease: 'linear',
+        }}
+      />
+      {label && (
+        <span className={`text-gray-500 dark:text-gray-400 ${size === 'sm' ? 'text-xs' : 'text-sm'}`}>
+          {label}
+        </span>
+      )}
+    </div>
+  )
+
+  if (fullScreen) {
+    return (
+      <div className="min-h-screen bg-background dark:bg-gray-900 flex items-center justify-center">
+        {spinner}
+      </div>
+    )
+  }
+
+  return spinner
+}

--- a/packages/ui/src/spinner/index.ts
+++ b/packages/ui/src/spinner/index.ts
@@ -1,0 +1,2 @@
+export { Spinner } from './Spinner'
+export type { SpinnerProps } from './Spinner'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
 
   packages/ui:
     dependencies:
+      framer-motion:
+        specifier: ^12.34.0
+        version: 12.34.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -6454,6 +6457,25 @@ packages:
       fetch-blob: 3.2.0
     dev: true
 
+  /framer-motion@12.34.0:
+    resolution: {integrity: sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      motion-dom: 12.34.0
+      motion-utils: 12.29.2
+      tslib: 2.8.1
+    dev: false
+
   /freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
     engines: {node: '>=8'}
@@ -8194,6 +8216,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dev: true
+
+  /motion-dom@12.34.0:
+    resolution: {integrity: sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q==}
+    dependencies:
+      motion-utils: 12.29.2
+    dev: false
+
+  /motion-utils@12.29.2:
+    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
+    dev: false
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}


### PR DESCRIPTION
## Summary
- `event_type`을 `fixed/flexible/recurring`에서 `anchor/hard/soft`로 교체하고 타입별 전용 컬럼 9개 추가
- EventModal을 3탭 셀렉터 + 조건부 입력 폼으로 전면 재설계 (앵커: 기준시간/목표시간/버퍼, 하드: 날짜/시간/반복요일/잠금/장소, 소프트: 주간목표/선호시간대/우선순위)
- PieChart 타입별 시각 차별화 + 메인 페이지 요일별 필터링 + 캘린더 페이지 데이터 fetch 버그 수정

## Changes
- **DB/Types**: `packages/supabase/schema.sql`, `packages/supabase/src/types.ts` - 새 event_type 값 + 9개 컬럼 추가
- **Constants**: `packages/core/src/constants/purposes.ts` - SCHEDULE_TYPES, PURPOSES_BY_TYPE, PREFERRED_WINDOWS
- **EventModal**: `apps/web/app/components/EventModal.tsx` - 3탭 + 타입별 조건부 폼
- **PieChart**: `packages/ui/src/pie-chart/PieChart.tsx` - 앵커(파스텔), 하드(굵은선), 소프트(점선)
- **Main Page**: `apps/web/app/page.tsx` - 요일별 이벤트 필터링 + purpose/type emoji 표시
- **Calendar**: `apps/web/app/calendar/page.tsx` - useUserData 훅 추가 (새로고침 데이터 유지)

## Test plan
- [ ] DB 마이그레이션 SQL 실행 (purpose 컬럼 + event_type CHECK + 9개 새 컬럼)
- [ ] EventModal에서 각 타입(앵커/하드/소프트) 탭 전환 시 폼 변경 확인
- [ ] 각 타입별 이벤트 생성 → DB 저장 → 새로고침 후 유지 확인
- [ ] 파이 차트에서 타입별 시각 스타일 확인 (opacity, stroke, dasharray)
- [ ] 캘린더 페이지 새로고침 시 이벤트 유지 확인
- [ ] `pnpm turbo build` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Three new event types—anchor, hard, and soft—each with tailored configuration options and visual badges
  * Event categorization system (work, meeting, exercise, study, meal, sleep, etc.) with emoji indicators
  * Enhanced calendar view with improved event filtering and type-specific styling
  * New loading spinner component for better UX feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->