### PR TITLE
feat: Web Push 알림 + 세션 만료 감지 + 안티패턴 수정

### DIFF
--- a/apps/web/app/api/push/subscribe/route.ts
+++ b/apps/web/app/api/push/subscribe/route.ts
@@ -33,7 +33,10 @@ async function getAuthUser() {
     }
   )
   const { data: { user }, error } = await supabase.auth.getUser()
-  if (error || !user) return null
+  if (error || !user) {
+    console.error('Push auth failed:', error?.message || 'No user')
+    return null
+  }
   return user
 }
 

--- a/packages/core/src/hooks/usePushNotification.ts
+++ b/packages/core/src/hooks/usePushNotification.ts
@@ -85,16 +85,20 @@ export function usePushNotification({
         applicationServerKey: keyArray.buffer as ArrayBuffer,
       })
 
-      // 서버에 구독 정보 저장 (userId는 서버에서 세션으로 확인)
+      // 서버에 구독 정보 저장 (userId는 서버에서 세션 쿠키로 확인)
       const res = await fetch('/api/push/subscribe', {
         method: 'POST',
+        credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           subscription: subscription.toJSON(),
         }),
       })
 
-      if (!res.ok) throw new Error('Failed to save subscription')
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(`Failed to save subscription: ${res.status} ${body.error || ''}`)
+      }
 
       setIsSubscribed(true)
       return true
@@ -120,6 +124,7 @@ export function usePushNotification({
         await subscription.unsubscribe()
         await fetch('/api/push/subscribe', {
           method: 'DELETE',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             endpoint: subscription.endpoint,


### PR DESCRIPTION
## Summary
- **Web Push 알림 시스템**: Service Worker, VAPID, pg_cron 기반 푸시 알림 구현
- **세션 만료 감지**: 탭 복귀 시 세션 만료 감지 및 로그인 리다이렉트
- **안티패턴 수정**: God Hook 분리, 타입 불일치/무한 루프 수정
- **코드 리뷰 반영**: 보안(세션 인증), 안정성(try/catch), 접근성(aria) 개선

### Web Push 알림
- Service Worker push/notificationclick 핸들러
- `usePushNotification` 훅 (구독/해제, SW 타임아웃 안전 처리)
- Supabase pg_cron + pg_net으로 매분 리마인더 푸시 발송
- PWA InstallPrompt (Android/iOS 분기)
- 설정 페이지 푸시 알림 토글

### 세션 만료 감지
- `visibilitychange` 이벤트로 탭 복귀 시 세션 체크
- 만료 시 자동 로그인 페이지 리다이렉트
- Edge Runtime 호환 constants 별도 export

### 안티패턴 수정
- `useUserData` God Hook → `useEventData`, `useExecutionData`, `useHabitData`, `useTodoData` 분리
- Supabase client lazy initialization (Proxy 패턴)

## 배포 전 필요 작업
- [x] Vercel 환경변수: `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_CONTACT_EMAIL`, `CRON_SECRET`
- [x] Supabase 마이그레이션: `20260315_push_subscriptions.sql`
- [x] Supabase Extensions: `pg_cron`, `pg_net` 활성화
- [x] Supabase SQL Editor: `20260316_pg_cron_push_notify.sql` 실행 (도메인/시크릿 교체)

## Test plan
- [x] 설정 페이지 푸시 알림 토글 ON → 브라우저 권한 요청
- [ ] Supabase `push_subscriptions` 테이블에 구독 저장 확인
- [ ] 탭 전환 후 복귀 시 세션 만료 감지 동작 확인
- [ ] iOS Safari InstallPrompt 안내 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Strengthened error handling for push notification subscriptions with enhanced logging and clearer error messages displayed when subscription operations fail
* Improved authentication reliability for push notification management by ensuring proper credential handling during all subscription and unsubscription requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->