### PR TITLE
fix: 캘린더 페이지 할일 즉시 반영 (#28)

### DIFF
--- a/apps/web/app/calendar/page.tsx
+++ b/apps/web/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { isSameLocalDate, toDateString, useEventData, useEventStore, useMonthEvents, useTodoStore, useUIStore } from '@time-pie/core'
+import { isSameLocalDate, toDateString, useEventData, useEventStore, useMonthEvents, useTodosQuery, useUIStore } from '@time-pie/core'
 import type { Event, EventInsert, EventMonthMeta } from '@time-pie/supabase'
 import { getEventById } from '@time-pie/supabase'
 import { useState } from 'react'
@@ -21,7 +21,7 @@ export default function CalendarPage() {
   const storeEvents = useEventStore((s) => s.events)
   const selectedDate = useEventStore((s) => s.selectedDate)
   const setSelectedDate = useEventStore((s) => s.setSelectedDate)
-  const todos = useTodoStore((s) => s.todos)
+  const { data: todosData } = useTodosQuery(user?.id)
   const viewMode = useUIStore((s) => s.calendarViewMode)
   const setViewMode = useUIStore((s) => s.setCalendarViewMode)
   const weekStartDay = useUIStore((s) => s.weekStartDay)
@@ -66,7 +66,7 @@ export default function CalendarPage() {
 
   const getTodosForDate = (date: Date) => {
     const dateStr = toDateString(date)
-    return todos.filter((t) => t.due_date === dateStr)
+    return (todosData ?? []).filter((t) => t.due_date === dateStr)
   }
 
   const handleSaveEvent = async (event: Omit<EventInsert, 'user_id'>) => {


### PR DESCRIPTION
## Summary
- 캘린더 페이지에서 할일 데이터 소스를 `useTodoStore` (Zustand) → `useTodosQuery` (React Query)로 변경
- 할일 생성/수정/삭제 시 React Query 캐시 invalidation을 통해 캘린더에도 즉시 반영

## 원인
- 할일 페이지는 `useTodosQuery`로 서버 데이터를 구독하여 mutation 후 자동 갱신
- 캘린더 페이지는 `useTodoStore`만 사용하여 React Query invalidation과 동기화되지 않았음

## Test plan
- [x] 할일 페이지에서 할일 생성 후 캘린더 페이지로 이동 → 즉시 반영 확인
- [x] 할일 수정/삭제 후 캘린더 반영 확인
- [x] 캘린더 페이지 직접 진입 시 할일 정상 표시 확인

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the calendar's data loading mechanism to improve task data consistency and real-time synchronization across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->