### PR TITLE
fix: 할일 CRUD 즉시 반영 (React Query mutation 전환)

### DIFF
--- a/apps/web/app/todos/page.tsx
+++ b/apps/web/app/todos/page.tsx
@@ -69,8 +69,9 @@ export default function TodosPage() {
 
   const handleAddTodo = useCallback(
     async (todo: Omit<TodoInsert, 'user_id'>) => {
+      if (!user) return
       try {
-        await createMutation.mutateAsync({ ...todo, user_id: user!.id })
+        await createMutation.mutateAsync({ ...todo, user_id: user.id })
         setModalOpen(false)
       } catch (error) {
         console.error('Failed to create todo:', error)


### PR DESCRIPTION
## Summary
- 할일 페이지의 생성/삭제/수정/토글 mutation을 레거시 `useTodoData`(Zustand) → React Query mutation 훅으로 전환
- mutation 후 `queryClient.invalidateQueries`로 캐시 자동 무효화되어 UI 즉시 반영
- 캘린더 페이지의 `useTodosQuery`도 동일 query key 사용하므로 함께 동기화

## 원인
데이터 표시는 `todosData`(React Query)를 우선 사용하지만, mutation은 Zustand store만 업데이트하여 React Query 캐시와 불일치 발생

## 변경 파일
- `apps/web/app/todos/page.tsx`

## Test plan
- [ ] 할일 생성 → 목록에 즉시 표시
- [ ] 할일 삭제 → 목록에서 즉시 제거
- [ ] 할일 수정 → 변경사항 즉시 반영
- [ ] 할일 완료 토글 → 즉시 반영
- [ ] 캘린더 페이지에서 할일 데이터 동기화 확인

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved todo management system architecture by updating the underlying data handling mechanism for create, update, delete, and toggle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->