### PR TITLE
feat: 주간 리포트 기능 추가

### DIFF
--- a/apps/web/app/api/cron/notify/route.ts
+++ b/apps/web/app/api/cron/notify/route.ts
@@ -162,7 +162,9 @@ async function sendEventNotifications(
         const alarmTimeMs = eventStartMs - reminderMin * 60 * 1000
         if (nowMs >= alarmTimeMs && nowMs < alarmTimeMs + 60000) {
           const minutesUntil = Math.round((eventStartMs - nowMs) / 60000)
-          const body = `${minutesUntil}분 후 시작됩니다`
+          const body = minutesUntil > 0
+            ? `${minutesUntil}분 후 시작됩니다`
+            : '곧 시작됩니다'
 
           notifications.push({
             userId: event.user_id,

--- a/apps/web/app/api/cron/notify/route.ts
+++ b/apps/web/app/api/cron/notify/route.ts
@@ -162,12 +162,12 @@ async function sendEventNotifications(
         const alarmTimeMs = eventStartMs - reminderMin * 60 * 1000
         if (nowMs >= alarmTimeMs && nowMs < alarmTimeMs + 60000) {
           const minutesUntil = Math.round((eventStartMs - nowMs) / 60000)
-          const body = minutesUntil > 0 ? `${minutesUntil}분 후 시작됩니다` : '곧 시작됩니다'
+          const body = `${minutesUntil}분 후 시작됩니다`
 
           notifications.push({
             userId: event.user_id,
             payload: JSON.stringify({
-              title: `🔔 ${event.title}`,
+              title: event.title,
               body,
               icon: '/assets/icon-192x192.png',
               tag: `event-${event.id}-${reminderMin}-${todayStr}`,
@@ -226,7 +226,7 @@ async function sendHabitNotifications(
         notifications.push({
           userId: habit.user_id,
           payload: JSON.stringify({
-            title: `🔔 ${habit.title}`,
+            title: habit.title,
             body: '습관을 실천할 시간입니다',
             icon: '/assets/icon-192x192.png',
             tag: `habit-${habit.id}-${todayStr}`,
@@ -280,7 +280,7 @@ async function sendTodoNotifications(
       const result = await sendPushToUsers(subsByUser, [{
         userId: todo.user_id,
         payload: JSON.stringify({
-          title: `📋 ${todo.title}`,
+          title: todo.title,
           body,
           icon: '/assets/icon-192x192.png',
           tag: `todo-${todo.id}`,

--- a/packages/core/src/hooks/useAlarm.ts
+++ b/packages/core/src/hooks/useAlarm.ts
@@ -166,7 +166,9 @@ export function useAlarm({ events, enabled, selectedDate }: UseAlarmOptions): Us
 
                     if (isInAlarmWindow) {
                         const minutesUntil = Math.round((eventStartMs - nowMs) / 60000)
-                        const body = `${minutesUntil}분 후 시작됩니다`
+                        const body = minutesUntil > 0
+                            ? `${minutesUntil}분 후 시작됩니다`
+                            : '곧 시작됩니다'
 
                         showNotification(event.title, {
                             body,

--- a/packages/core/src/hooks/useAlarm.ts
+++ b/packages/core/src/hooks/useAlarm.ts
@@ -166,11 +166,9 @@ export function useAlarm({ events, enabled, selectedDate }: UseAlarmOptions): Us
 
                     if (isInAlarmWindow) {
                         const minutesUntil = Math.round((eventStartMs - nowMs) / 60000)
-                        const body = minutesUntil > 0
-                            ? `${minutesUntil}분 후 시작됩니다`
-                            : '곧 시작됩니다'
+                        const body = `${minutesUntil}분 후 시작됩니다`
 
-                        showNotification(`🔔 ${event.title}`, {
+                        showNotification(event.title, {
                             body,
                             icon: '/assets/icon-192x192.png',
                             tag: alarmKey,

--- a/supabase/migrations/20260326_weekly_reports.sql
+++ b/supabase/migrations/20260326_weekly_reports.sql
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS weekly_reports (
   todo_summary JSONB NOT NULL DEFAULT '{}',
   ai_insights JSONB NOT NULL DEFAULT '[]',
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (week_end = week_start + 6),
+  CHECK (total_events >= 0),
+  CHECK (total_duration_min >= 0),
   UNIQUE(user_id, week_start)
 );
 

--- a/supabase/migrations/20260326_weekly_reports.sql
+++ b/supabase/migrations/20260326_weekly_reports.sql
@@ -1,0 +1,52 @@
+-- Weekly Reports 테이블 생성 + pg_cron 스케줄 등록
+--
+-- 사전 조건:
+--   1. pg_cron, pg_net 확장이 이미 활성화되어 있어야 함
+--   2. YOUR_DOMAIN, YOUR_CRON_SECRET 을 실제 값으로 교체
+
+-- 1. 테이블 생성
+CREATE TABLE IF NOT EXISTS weekly_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  week_start DATE NOT NULL,
+  week_end DATE NOT NULL,
+  total_events INTEGER NOT NULL DEFAULT 0,
+  total_duration_min INTEGER NOT NULL DEFAULT 0,
+  purpose_distribution JSONB NOT NULL DEFAULT '{}',
+  completion_rate NUMERIC(5,2) NOT NULL DEFAULT 0,
+  daily_completion JSONB NOT NULL DEFAULT '[]',
+  prev_week_comparison JSONB,
+  habit_summary JSONB NOT NULL DEFAULT '{}',
+  todo_summary JSONB NOT NULL DEFAULT '{}',
+  ai_insights JSONB NOT NULL DEFAULT '[]',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, week_start)
+);
+
+-- 2. RLS 활성화
+ALTER TABLE weekly_reports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Users can view own weekly reports" ON weekly_reports;
+CREATE POLICY "Users can view own weekly reports" ON weekly_reports
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- Service role full access (cron job이 데이터를 upsert하기 위해 필요)
+DROP POLICY IF EXISTS "Service role full access on weekly reports" ON weekly_reports;
+CREATE POLICY "Service role full access on weekly reports" ON weekly_reports
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- 3. 인덱스
+CREATE INDEX IF NOT EXISTS idx_weekly_reports_user_week
+  ON weekly_reports(user_id, week_start DESC);
+
+-- 4. pg_cron 스케줄: 매주 월요일 00:00 UTC (09:00 KST)
+select cron.schedule(
+  'weekly-report-every-monday',
+  '0 0 * * 1',
+  $$
+  select net.http_get(
+    url := 'https://YOUR_DOMAIN/api/cron/weekly-report',
+    headers := '{"Authorization": "Bearer YOUR_CRON_SECRET"}'::jsonb
+  );
+  $$
+);


### PR DESCRIPTION
## Summary

- 매주 월요일 자동으로 전주(월~일) 데이터를 집계하는 cron job 추가 (`/api/cron/weekly-report`)
- 주간 리포트 조회 페이지 (`/reports`) 및 하위 컴포넌트 6종 구현
- `weekly_reports` 테이블, RLS 정책, pg_cron 스케줄 마이그레이션 추가

### 리포트 내용
- 주간 요약 (총 시간, 이벤트 수, 완료율 + 전주 대비 변화)
- 유형별 시간 분포 (도넛 차트)
- 일별 완료율 (바 차트)
- 습관/할일 요약
- 규칙 기반 AI 인사이트 (성취, 경고, 패턴)

### 아키텍처
- Cron: pg_cron + pg_net → `/api/cron/weekly-report` (매주 월 00:00 UTC)
- 데이터: `packages/supabase/src/queries/reports.ts` → `packages/core/src/hooks/queries/reports.ts`
- UI: `apps/web/app/reports/` (WeekSelector, WeeklySummaryCard, PurposeDistributionChart, DailyCompletionChart, HabitTodoSummary, AIInsightsSection)

## Known Issues

- #52 유저 수 증가 시 병렬 처리 배치 제한 필요
- #53 주 경계를 걸치는 이벤트 누락 가능
- #54 미사용 `createWeeklyReport` 함수 정리
- #55 `DailyCompletionChart` maxRate 변수 미사용

## Test plan

- [x] `curl -H "Authorization: Bearer $CRON_SECRET" $URL/api/cron/weekly-report` → `{"processed":5,"total_users":5}`
- [ ] `/reports` 페이지에서 주간 리포트 정상 표시 확인
- [ ] 리포트 없을 때 빈 상태 UI 확인
- [ ] 주 선택기로 다른 주 전환 확인
- [ ] 다크모드에서 차트/카드 스타일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekly reports with aggregated activity metrics, completion rates, purpose breakdowns, daily completion trends, habit/todo summaries, and AI insights; reports are generated automatically each Monday.

* **Style**
  * Simplified notification text for events, habits, and todos by removing emoji prefixes and normalizing message phrasing (same timing rules preserved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->